### PR TITLE
Downgrade inflection 0.5.0 to 0.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Click==7.1.2
 click-default-group==1.2.2
 contextlib2==0.6.0.post1
 future==0.18.2
-inflection==0.5.0
+inflection==0.3.1 # pyup: >=0.3.1,<0.4 # 0.4 drops Python 2.7 support
 isodate==0.6.0
 lxml==4.5.2
 markdown==3.1.1 # pyup: >=3.1,<3.2 # 3.2 drops Python 2.7 support


### PR DESCRIPTION
This PR downgrade [inflection](https://pypi.org/project/inflection/) from version **0.5.0** to **0.3.1**.

Version **0.4.0** dropped Python 2.7 support and updating up to version **0.5.0** in #182 and pinning version to **0.4.0** in 7dcf55a050d7d92dac6c01e6384375ca79a33fd8 have both been mistakes.

Version has also been pinned to minor version **0.3** for pyup.